### PR TITLE
Add validation script and update tests doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,20 @@
 1. Add a remote repository with `git remote add origin <URL>` if your local clone does not yet have one.
 2. Use clear commit messages that briefly summarize the change. For example, `Add official website field to 小平市 council list`.
 3. Commit your changes, push them to a branch on the remote, and open a pull request on the hosting platform.
+
+## Tests
+
+If `pytest` is installed, run the test suite from the repository root:
+
+```bash
+pytest
+```
+
+These tests load files in `data/processed` and validate them against
+`schema/municipal_councillor_v1.1.json`.
+
+For environments without `pytest`, the same validation can be performed using:
+
+```bash
+python scripts/validate_data.py
+```

--- a/scripts/validate_data.py
+++ b/scripts/validate_data.py
@@ -1,0 +1,40 @@
+import glob
+import json
+import os
+import sys
+
+ROOT_DIR = os.path.join(os.path.dirname(__file__), '..')
+sys.path.insert(0, ROOT_DIR)
+from tests.jsonschema import validate, ValidationError
+
+SCHEMA_PATH = os.path.join(ROOT_DIR, 'schema', 'municipal_councillor_v1.1.json')
+DATA_DIR = os.path.join(ROOT_DIR, 'data', 'processed')
+
+
+def main():
+    with open(SCHEMA_PATH, encoding='utf-8') as f:
+        schema = json.load(f)
+
+    json_files = glob.glob(os.path.join(DATA_DIR, '*.json'))
+    if not json_files:
+        print('No JSON files found in processed data directory')
+        return 1
+
+    for path in json_files:
+        with open(path, encoding='utf-8') as f:
+            data = json.load(f)
+        if not isinstance(data, list):
+            print(f'{path}: file does not contain a list of objects')
+            return 1
+        for item in data:
+            try:
+                validate(item, schema)
+            except ValidationError as e:
+                print(f'{path}: {e}')
+                return 1
+    print('All files valid')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- provide instructions for running tests with `pytest`
- document a script for schema validation without `pytest`
- add `scripts/validate_data.py` to run the validation manually

## Testing
- `pytest -q` *(fails: command not found)*
- `python scripts/validate_data.py`