### PR TITLE
HTMLビューアを静的データ版に改善

### DIFF
--- a/viewer/index.html
+++ b/viewer/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>市議会議員データビューア</title>
+    <title>市町村議会議員データビューア</title>
     <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
@@ -21,10 +21,13 @@
         </main>
         
         <footer>
-            <p>&copy; 2025 市議会議員データビューア</p>
+            <p>&copy; 2025 市町村議会議員データビューア</p>
         </footer>
     </div>
     
-    <script src="js/index.js"></script>
+    <script src="js/data.js"></script>
+    <script src="js/index-simple.js"></script>
+    <!-- デバッグ用：動的読み込み版は以下をコメントアウトを外して使用 -->
+    <!-- <script src="js/index.js"></script> -->
 </body>
 </html>

--- a/viewer/js/data.js
+++ b/viewer/js/data.js
@@ -1,0 +1,49 @@
+// 議員データ（2025年5月29日現在）
+const municipalityData = {
+    // 東京都
+    '132012': { name: '八王子市', prefecture: '13_東京都', count: 38, xCount: 5 },
+    '132021': { name: '立川市', prefecture: '13_東京都', count: 24, xCount: 8 },
+    '132039': { name: '武蔵野市', prefecture: '13_東京都', count: 25, xCount: 15 },
+    '132047': { name: '三鷹市', prefecture: '13_東京都', count: 28, xCount: 5 },
+    '132055': { name: '青梅市', prefecture: '13_東京都', count: 24, xCount: 2 },
+    '132063': { name: '府中市', prefecture: '13_東京都', count: 29, xCount: 4 },
+    '132071': { name: '昭島市', prefecture: '13_東京都', count: 22, xCount: 9 },
+    '132080': { name: '調布市', prefecture: '13_東京都', count: 28, xCount: 5 },
+    '132098': { name: '町田市', prefecture: '13_東京都', count: 33, xCount: 16 },
+    '132101': { name: '小金井市', prefecture: '13_東京都', count: 24, xCount: 8 },
+    '132110': { name: '小平市', prefecture: '13_東京都', count: 27, xCount: 14 },
+    '132128': { name: '日野市', prefecture: '13_東京都', count: 23, xCount: 8 },
+    '132136': { name: '東村山市', prefecture: '13_東京都', count: 24, xCount: 5 },
+    '132144': { name: '国分寺市', prefecture: '13_東京都', count: 20, xCount: 5 },
+    '132152': { name: '国立市', prefecture: '13_東京都', count: 21, xCount: 1 },
+    '132187': { name: '福生市', prefecture: '13_東京都', count: 18, xCount: 0 },
+    '132195': { name: '狛江市', prefecture: '13_東京都', count: 22, xCount: 2 },
+    '132209': { name: '東大和市', prefecture: '13_東京都', count: 21, xCount: 4 },
+    '132217': { name: '清瀬市', prefecture: '13_東京都', count: 20, xCount: 5 },
+    '132225': { name: '東久留米市', prefecture: '13_東京都', count: 21, xCount: 6 },
+    '132233': { name: '武蔵村山市', prefecture: '13_東京都', count: 20, xCount: 10 },
+    '132241': { name: '多摩市', prefecture: '13_東京都', count: 23, xCount: 0 },
+    '132250': { name: '稲城市', prefecture: '13_東京都', count: 22, xCount: 0 },
+    '132276': { name: '羽村市', prefecture: '13_東京都', count: 18, xCount: 0 },
+    '132284': { name: 'あきる野市', prefecture: '13_東京都', count: 21, xCount: 2 },
+    '132292': { name: '西東京市', prefecture: '13_東京都', count: 28, xCount: 1 },
+    
+    // 東京都町村
+    '133035': { name: '瑞穂町', prefecture: '13_東京都', count: 15, xCount: 0 },
+    '133051': { name: '日の出町', prefecture: '13_東京都', count: 14, xCount: 0 },
+    '133078': { name: '檜原村', prefecture: '13_東京都', count: 8, xCount: 0 },
+    '133086': { name: '奥多摩町', prefecture: '13_東京都', count: 10, xCount: 0 },
+    '133612': { name: '大島町', prefecture: '13_東京都', count: 14, xCount: 0 },
+    '133621': { name: '利島村', prefecture: '13_東京都', count: 6, xCount: 0 },
+    '133639': { name: '新島村', prefecture: '13_東京都', count: 10, xCount: 0 },
+    '133647': { name: '神津島村', prefecture: '13_東京都', count: 8, xCount: 0 },
+    '133817': { name: '三宅村', prefecture: '13_東京都', count: 7, xCount: 0 },
+    '133825': { name: '御蔵島村', prefecture: '13_東京都', count: 6, xCount: 0 },
+    '134015': { name: '八丈町', prefecture: '13_東京都', count: 12, xCount: 0 },
+    '134023': { name: '青ヶ島村', prefecture: '13_東京都', count: 0, xCount: 0 }, // データ未収集
+    '134210': { name: '小笠原村', prefecture: '13_東京都', count: 8, xCount: 1 },
+    
+    // 埼玉県
+    '112089': { name: '所沢市', prefecture: '11_埼玉県', count: 33, xCount: 5 },
+    '112259': { name: '入間市', prefecture: '11_埼玉県', count: 22, xCount: 11 }
+};

--- a/viewer/js/index-simple.js
+++ b/viewer/js/index-simple.js
@@ -1,0 +1,44 @@
+// シンプルな静的データ表示版
+function displayMunicipalities() {
+    const container = document.getElementById('municipality-list');
+    
+    // データを配列に変換
+    const municipalities = Object.entries(municipalityData).map(([code, data]) => ({
+        code,
+        ...data
+    }));
+    
+    // 都道府県別にグループ化
+    const grouped = {
+        '東京都': municipalities.filter(m => m.prefecture === '13_東京都'),
+        '埼玉県': municipalities.filter(m => m.prefecture === '11_埼玉県')
+    };
+    
+    // HTML生成
+    let html = '';
+    
+    for (const [prefName, munis] of Object.entries(grouped)) {
+        if (munis.length > 0) {
+            html += `<h3 style="grid-column: 1 / -1; margin-top: 20px;">${prefName}</h3>`;
+            
+            // 自治体名でソート
+            munis.sort((a, b) => a.name.localeCompare(b.name, 'ja'));
+            
+            html += munis.map(m => {
+                const percentage = m.count > 0 ? Math.round(m.xCount / m.count * 100) : 0;
+                return `
+                    <div class="municipality-card" style="cursor: pointer;" onclick="alert('${m.name}の詳細ページは準備中です')">
+                        <h4>${m.name}</h4>
+                        <div class="councillor-count">議員数: ${m.count}名</div>
+                        <div class="x-count">X登録: ${m.xCount}名 (${percentage}%)</div>
+                    </div>
+                `;
+            }).join('');
+        }
+    }
+    
+    container.innerHTML = html;
+}
+
+// ページ読み込み時に実行
+document.addEventListener('DOMContentLoaded', displayMunicipalities);


### PR DESCRIPTION
## 概要
GitHub PagesでのCORS問題を解決するため、HTMLビューアを静的データ版に変更しました。

## 変更内容

### 1. 静的データファイルの追加
- `js/data.js`: 全自治体の議員数・X登録数を静的データとして定義
- 2025年5月29日現在のデータを反映（入間市の更新含む）

### 2. シンプルな表示実装
- `js/index-simple.js`: 静的データを読み込んで表示
- CORS問題を完全に回避
- 高速な表示を実現

### 3. デバッグ機能の保持
- 元の動的読み込み版（`index.js`）も保持
- コンソールログで詳細なデバッグ情報を出力
- 将来的な機能拡張に対応

### 4. UI改善
- タイトルを「市町村議会議員データビューア」に統一
- 自治体カードのクリック時に「準備中」メッセージを表示

## 動作確認方法
1. GitHub Pagesで `https://[username].github.io/City_Council-/viewer/` にアクセス
2. 全41自治体が表示されることを確認
3. 各自治体の議員数とX登録率が正しく表示されることを確認

## 今後の改善予定
- 議員詳細ページの実装
- 検索・フィルター機能の追加
- データ自動更新の仕組み

🤖 Generated with [Claude Code](https://claude.ai/code)