### PR TITLE
議員詳細ページへのリンクを有効化

### DIFF
--- a/viewer/js/index-simple.js
+++ b/viewer/js/index-simple.js
@@ -27,11 +27,11 @@ function displayMunicipalities() {
             html += munis.map(m => {
                 const percentage = m.count > 0 ? Math.round(m.xCount / m.count * 100) : 0;
                 return `
-                    <div class="municipality-card" style="cursor: pointer;" onclick="alert('${m.name}の詳細ページは準備中です')">
+                    <a href="municipality.html?code=${m.code}&name=${encodeURIComponent(m.name)}&prefecture=${encodeURIComponent(m.prefecture)}" class="municipality-card">
                         <h4>${m.name}</h4>
                         <div class="councillor-count">議員数: ${m.count}名</div>
                         <div class="x-count">X登録: ${m.xCount}名 (${percentage}%)</div>
-                    </div>
+                    </a>
                 `;
             }).join('');
         }


### PR DESCRIPTION
## 概要
自治体カードをクリックしたときに、議員詳細ページへ遷移するように修正しました。

## 変更内容
- 「準備中」アラートを削除
- `municipality.html`へのリンクを設定

## 注意事項
詳細ページ（`municipality.html`）は現在JSONファイルを動的に読み込む仕組みのため、GitHub PagesではCORS制限により動作しない可能性があります。

## 今後の対応
詳細ページも静的データ版に対応させる必要があります。これは別のPRで対応予定です。

🤖 Generated with [Claude Code](https://claude.ai/code)