### PR TITLE
ビューアのキャッシュ問題を修正

### DIFF
--- a/viewer/index.html
+++ b/viewer/index.html
@@ -25,8 +25,22 @@
         </footer>
     </div>
     
-    <script src="js/data.js"></script>
-    <script src="js/index-simple.js"></script>
+    <script>
+        // キャッシュバスティング用のタイムスタンプを生成
+        const version = new Date().getTime();
+        
+        // data.jsを動的に読み込み
+        const dataScript = document.createElement('script');
+        dataScript.src = `js/data.js?v=${version}`;
+        document.head.appendChild(dataScript);
+        
+        // index-simple.jsを動的に読み込み
+        dataScript.onload = function() {
+            const indexScript = document.createElement('script');
+            indexScript.src = `js/index-simple.js?v=${version}`;
+            document.head.appendChild(indexScript);
+        };
+    </script>
     <!-- デバッグ用：動的読み込み版は以下をコメントアウトを外して使用 -->
     <!-- <script src="js/index.js"></script> -->
 </body>

--- a/viewer/js/municipality-static.js
+++ b/viewer/js/municipality-static.js
@@ -29,9 +29,10 @@ async function initialize() {
 
 // Load councillor data from static JS file
 function loadStaticData() {
-    // 静的データファイルを動的に読み込む
+    // 静的データファイルを動的に読み込む（キャッシュバスティング付き）
     const script = document.createElement('script');
-    script.src = `js/municipalities/${municipalityCode}.js`;
+    const version = new Date().getTime();
+    script.src = `js/municipalities/${municipalityCode}.js?v=${version}`;
     
     console.log('Loading script:', script.src);
     

--- a/viewer/municipality.html
+++ b/viewer/municipality.html
@@ -58,7 +58,15 @@
         </footer>
     </div>
     
-    <script src="js/municipality-static.js"></script>
+    <script>
+        // キャッシュバスティング用のタイムスタンプを生成
+        const version = new Date().getTime();
+        
+        // municipality-static.jsを動的に読み込み
+        const municipalityScript = document.createElement('script');
+        municipalityScript.src = `js/municipality-static.js?v=${version}`;
+        document.head.appendChild(municipalityScript);
+    </script>
     <!-- デバッグ用：動的読み込み版は以下をコメントアウトを外して使用 -->
     <!-- <script src="js/municipality.js"></script> -->
 </body>


### PR DESCRIPTION
## 概要
Windows 11のFirefoxでビューアのデータが更新されない問題を修正しました。

## 問題
- Windows 11のFirefoxで、手動でキャッシュをクリアしないと更新されたデータが表示されない
- iPhoneでは問題なく即座に更新が反映される

## 解決策
JavaScriptファイルの読み込みにタイムスタンプベースのキャッシュバスティングを実装しました。

### 変更内容
1. **index.html**
   - `data.js`と`index-simple.js`を動的読み込みに変更
   - タイムスタンプクエリパラメータ（`?v=${version}`）を追加

2. **municipality.html**  
   - `municipality-static.js`を動的読み込みに変更
   - 同様にタイムスタンプクエリパラメータを追加

3. **municipality-static.js**
   - 個別自治体データファイル（`municipalities/${code}.js`）の読み込みにもキャッシュバスティングを追加

## 効果
- ブラウザは常に最新バージョンのファイルを取得
- 手動でのキャッシュクリアが不要に
- 全てのブラウザで一貫した動作を実現

## テスト方法
1. ビューアを開く
2. データを更新（新しいX登録など）
3. ページをリロード
4. 更新が即座に反映されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)