### PR TITLE
ビューアのスクリプト読み込み順序の問題を修正

### DIFF
--- a/viewer/index.html
+++ b/viewer/index.html
@@ -32,13 +32,24 @@
         // data.jsを動的に読み込み
         const dataScript = document.createElement('script');
         dataScript.src = `js/data.js?v=${version}`;
-        document.head.appendChild(dataScript);
+        document.body.appendChild(dataScript);
         
-        // index-simple.jsを動的に読み込み
+        // data.jsの読み込み完了後にindex-simple.jsを読み込み
         dataScript.onload = function() {
             const indexScript = document.createElement('script');
             indexScript.src = `js/index-simple.js?v=${version}`;
-            document.head.appendChild(indexScript);
+            document.body.appendChild(indexScript);
+            
+            // index-simple.jsの読み込み完了後に初期化関数を実行
+            indexScript.onload = function() {
+                // DOMContentLoadedが既に発火している場合のために直接実行
+                if (document.readyState === 'loading') {
+                    document.addEventListener('DOMContentLoaded', displayMunicipalities);
+                } else {
+                    // 既にDOMが読み込まれている場合は直接実行
+                    displayMunicipalities();
+                }
+            };
         };
     </script>
     <!-- デバッグ用：動的読み込み版は以下をコメントアウトを外して使用 -->


### PR DESCRIPTION
## 問題
キャッシュバスティング実装後、ビューアのトップ画面に市町村名が表示されず、選択もできない状態になっていました。

## 原因
動的スクリプト読み込みにおいて、以下の問題が発生していました：
1. `DOMContentLoaded`イベントが既に発火済みの状態で`index-simple.js`が読み込まれる
2. そのため`displayMunicipalities()`関数が実行されない
3. 結果として市町村一覧が表示されない

## 解決策
`index.html`のスクリプト読み込み処理を修正：
1. スクリプトを`document.head`ではなく`document.body`に追加
2. `index-simple.js`の読み込み完了後に、`document.readyState`をチェック
3. DOMが既に読み込まれている場合は直接`displayMunicipalities()`を実行

## テスト項目
- [x] 市町村一覧が正しく表示される
- [x] キャッシュバスティングが引き続き機能する
- [x] 各市町村をクリックして詳細ページに遷移できる

🤖 Generated with [Claude Code](https://claude.ai/code)