### PR TITLE
議員一覧ページのスクリプト読み込み問題を修正

### DIFF
--- a/viewer/municipality.html
+++ b/viewer/municipality.html
@@ -65,7 +65,18 @@
         // municipality-static.jsを動的に読み込み
         const municipalityScript = document.createElement('script');
         municipalityScript.src = `js/municipality-static.js?v=${version}`;
-        document.head.appendChild(municipalityScript);
+        document.body.appendChild(municipalityScript);
+        
+        // スクリプトの読み込み完了後に初期化関数を実行
+        municipalityScript.onload = function() {
+            // DOMContentLoadedが既に発火している場合のために直接実行
+            if (document.readyState === 'loading') {
+                document.addEventListener('DOMContentLoaded', initialize);
+            } else {
+                // 既にDOMが読み込まれている場合は直接実行
+                initialize();
+            }
+        };
     </script>
     <!-- デバッグ用：動的読み込み版は以下をコメントアウトを外して使用 -->
     <!-- <script src="js/municipality.js"></script> -->


### PR DESCRIPTION
## 概要
PR #63で市町村一覧ページの問題は修正されましたが、議員一覧ページ（municipality.html）でも同様の問題が発生していたため、追加で修正しました。

## 問題
議員一覧ページで議員情報が表示されない

## 原因
`municipality.html`でも動的スクリプト読み込み時に`DOMContentLoaded`イベントのタイミング問題が発生

## 解決策
`municipality.html`のスクリプト読み込み処理を修正：
1. スクリプトを`document.body`に追加
2. `municipality-static.js`の読み込み完了後に`document.readyState`をチェック
3. DOMが既に読み込まれている場合は直接`initialize()`を実行

## テスト項目
- [x] 議員一覧が正しく表示される
- [x] 検索・フィルター機能が動作する
- [x] ソート機能が動作する
- [x] キャッシュバスティングが機能する

## 関連PR
- #63 （市町村一覧ページの修正）

🤖 Generated with [Claude Code](https://claude.ai/code)